### PR TITLE
bugfix(AULA-923) Wait for event request to complete before resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This is a quick start guide. For more information about the Inspector project please read the [Inspector SDK Reference](https://www.avo.app/docs/implementation/avo-inspector-sdk-reference) and the [Inspector Setup Guide](https://www.avo.app/docs/implementation/setup-inspector-sdk).
 
+# Why was this forked?
+At the time of writing, the latest version of node-avo-inspector from the original repository has an issue where the promise returned by `trackSchemaFromEvent` gets resolved before the request to send the event metadata to the tracking endpoint completes. If this function is used in an AWS Lambda, this results in errors since the lambda function finishes before the event metadata request completes. This fork addresses the issue.
+
 # Installation
 
 The library is distributed with npm, install with npm:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/node-avo-inspector",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0",
   "description": "Avo Inspector for Node.js",
   "main": "dist/index.js",
   "repository": "https://github.com/avohq/node-avo-inspector",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-avo-inspector",
-  "version": "1.0.3-beta.0",
+  "name": "@ublend-npm/node-avo-inspector",
+  "version": "1.1.0-beta.0",
   "description": "Avo Inspector for Node.js",
   "main": "dist/index.js",
   "repository": "https://github.com/avohq/node-avo-inspector",

--- a/src/AvoInspector.ts
+++ b/src/AvoInspector.ts
@@ -182,7 +182,7 @@ export class AvoInspector {
     }
   }
 
-  private trackSchemaInternal(
+  private async trackSchemaInternal(
     eventName: string,
     eventSchema: Array<{
       propertyName: string;
@@ -194,33 +194,33 @@ export class AvoInspector {
   ): Promise<void> {
     try {
       const seesionId = AvoGuid.newGuid();
-      return this.avoNetworkCallsHandler
-        .callInspectorWithBatchBody([
-          this.avoNetworkCallsHandler.bodyForSessionStartedCall(seesionId),
-        ])
-        .then(() => {
-          if (AvoInspector.shouldLog) {
-            console.log("Avo Inspector: session started sent successfully.");
-          }
-          this.avoNetworkCallsHandler.callInspectorWithBatchBody([
-            this.avoNetworkCallsHandler.bodyForEventSchemaCall(
-              seesionId,
-              eventName,
-              eventSchema,
-              eventId,
-              eventHash
-            ),
-          ]).then(() => {
-            if (AvoInspector.shouldLog) {
-              console.log("Avo Inspector: schema sent successfully.");
-            }
-          });
-        })
-        .catch((err) => {
-          if (AvoInspector.shouldLog) {
-            console.log("Avo Inspector: schema sending failed: " + err + ".");
-          }
-        });
+      try {
+        await this.avoNetworkCallsHandler
+          .callInspectorWithBatchBody([
+            this.avoNetworkCallsHandler.bodyForSessionStartedCall(seesionId),
+          ]);
+        if (AvoInspector.shouldLog) {
+          console.log("Avo Inspector: session started sent successfully.");
+        }
+
+        await this.avoNetworkCallsHandler.callInspectorWithBatchBody([
+          this.avoNetworkCallsHandler.bodyForEventSchemaCall(
+            seesionId,
+            eventName,
+            eventSchema,
+            eventId,
+            eventHash
+          ),
+        ]);
+
+        if (AvoInspector.shouldLog) {
+          console.log("Avo Inspector: schema sent successfully.");
+        }
+      } catch (err) {
+        if (AvoInspector.shouldLog) {
+          console.log("Avo Inspector: schema sending failed: " + err + ".");
+        }
+      }
     } catch (e) {
       console.error(
         "Avo Inspector: something went wrong. Please report to support@avo.app.",

--- a/src/__tests__/TestDeduplicator.ts
+++ b/src/__tests__/TestDeduplicator.ts
@@ -3,6 +3,10 @@ import { deepEquals } from "../utils";
 import { AvoInspector } from "../AvoInspector";
 import { defaultOptions } from "./constants";
 
+jest
+  .useFakeTimers('modern')
+  .setSystemTime(new Date('2020-01-01'));
+
 describe("Deduplicator", () => {
   const deduplicator = new AvoDeduplicator();
 


### PR DESCRIPTION
# Technical Context
Fixes the issue where the promise returned by the function `trackSchemaFromEvent` resolves before the request with event metadata completes.

## Changelog
<!--
 List the changes that this PR is bringing to the platform, making it as understandable as possible to anyone in the company.
 Please don't remove the code block.
 -->

```changelog
- Bug fix: Wait for all HTTP requests to complete before resolving promise returned by trackSchemaFromEvent
```

## Loom/Screenshot
<!--
 A loom with a walkthrough of the changes (or even of the PR when it's complex!)
 is always highly appreciated as it provides context to the reviewer.

 If it's a small visual change, a screenshot might be enough :)
 -->

## Review Guideline Cheatsheet

> Please refer to [this doc](https://www.notion.so/aulaatcoventry/Pull-Request-Guidelines-faa685630d36462693af7e3a53d9fa93) for the complete PR review guideline.

Emoji | Intention
---|---
🍰 `:cake:` | Nice to have, but not blocking
💡 `:bulb:` | Refactor suggestion or another idea that require relevant changes and may need a discussion
🤔 `:thinking:` | Something is not clear, can you give me more context?
🔨 `:hammer:` | Required change
🚀 `:rocket:` | Positive feedback
